### PR TITLE
Add license metadata to package info.rkt files

### DIFF
--- a/com-win32-i386/com/info.rkt
+++ b/com-win32-i386/com/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 (define copy-foreign-libs (quote ("myssink.dll")))
-(define collection 'multi)
 (define install-platform "win32\\i386")

--- a/com-win32-i386/info.rkt
+++ b/com-win32-i386/info.rkt
@@ -1,7 +1,12 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 (define collection 'multi)
 (define deps '("base"))
 
 (define pkg-desc "native libraries for \"base\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '(Apache-2.0 OR MIT))

--- a/com-win32-x86_64/com/info.rkt
+++ b/com-win32-x86_64/com/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 (define copy-foreign-libs (quote ("myssink.dll")))
-(define collection 'multi)
 (define install-platform "win32\\x86_64")

--- a/com-win32-x86_64/info.rkt
+++ b/com-win32-x86_64/info.rkt
@@ -1,7 +1,12 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 (define collection 'multi)
 (define deps '("base"))
 
 (define pkg-desc "native libraries for \"base\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '(Apache-2.0 OR MIT))

--- a/db-ppc-macosx/LICENSE.txt
+++ b/db-ppc-macosx/LICENSE.txt
@@ -1,9 +1,9 @@
 db-win32-macosx
 Copyright (c) 2010-2014 PLT Design Inc.
 
-This package is distributed under the Apache 2.0 and MIT licenses. The
-user can choose the license under which they will be using the
-software. There may be other licenses within the distribution with
-which the user must also comply.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 SQLite3 is in the public domain.

--- a/db-ppc-macosx/db/info.rkt
+++ b/db-ppc-macosx/db/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 (define copy-foreign-libs (quote ("libsqlite3.0.dylib")))
 (define collection 'multi)
 (define install-platform "ppc-macosx")

--- a/db-ppc-macosx/info.rkt
+++ b/db-ppc-macosx/info.rkt
@@ -1,7 +1,12 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 (define collection 'multi)
 (define deps '("base"))
 
-(define pkg-desc "native libraries for \"base\" package")
+(define pkg-desc "native libraries for \"db\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '(blessing AND (Apache-2.0 OR MIT)))

--- a/db-win32-arm64/LICENSE.txt
+++ b/db-win32-arm64/LICENSE.txt
@@ -1,8 +1,8 @@
 db-win32-arm64
 
-This package is distributed under the Apache 2.0 and MIT licenses. The
-user can choose the license under which they will be using the
-software. There may be other licenses within the distribution with
-which the user must also comply.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 SQLite3 is in the public domain.

--- a/db-win32-arm64/db/info.rkt
+++ b/db-win32-arm64/db/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "win32\\arm64")
 

--- a/db-win32-arm64/info.rkt
+++ b/db-win32-arm64/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +8,5 @@
 (define pkg-desc "native libraries for \"base\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license '((Apache-2.0 OR MIT) AND blessing))

--- a/db-win32-i386/LICENSE.txt
+++ b/db-win32-i386/LICENSE.txt
@@ -1,9 +1,8 @@
 db-win32-i386
-Copyright (c) 2010-2018 PLT Design Inc.
 
-This package is distributed under the Apache 2.0 and MIT licenses. The
-user can choose the license under which they will be using the
-software. There may be other licenses within the distribution with
-which the user must also comply.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 SQLite3 is in the public domain.

--- a/db-win32-i386/db/info.rkt
+++ b/db-win32-i386/db/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "win32\\i386")
 

--- a/db-win32-i386/info.rkt
+++ b/db-win32-i386/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +8,5 @@
 (define pkg-desc "native libraries for \"base\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license '((Apache-2.0 OR MIT) AND blessing))

--- a/db-win32-x86_64/LICENSE.txt
+++ b/db-win32-x86_64/LICENSE.txt
@@ -1,9 +1,8 @@
 db-win32-x86_64
-Copyright (c) 2010-2018 PLT Design Inc.
 
-This package is distributed under the Apache 2.0 and MIT licenses. The
-user can choose the license under which they will be using the
-software. There may be other licenses within the distribution with
-which the user must also comply.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 SQLite3 is in the public domain.

--- a/db-win32-x86_64/db/info.rkt
+++ b/db-win32-x86_64/db/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "win32\\x86_64")
 

--- a/db-win32-x86_64/info.rkt
+++ b/db-win32-x86_64/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +8,5 @@
 (define pkg-desc "native libraries for \"base\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license '((Apache-2.0 OR MIT) AND blessing))

--- a/db-x86_64-linux-natipkg/LICENSE.txt
+++ b/db-x86_64-linux-natipkg/LICENSE.txt
@@ -1,9 +1,8 @@
 db-x86_64-linux-natipkg
-Copyright (c) 2010-2018 PLT Design Inc.
 
-This package is distributed under the Apache 2.0 and MIT licenses. The
-user can choose the license under which they will be using the
-software. There may be other licenses within the distribution with
-which the user must also comply.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 SQLite3 is in the public domain.

--- a/db-x86_64-linux-natipkg/db/info.rkt
+++ b/db-x86_64-linux-natipkg/db/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "x86_64-linux-natipkg")
 

--- a/db-x86_64-linux-natipkg/info.rkt
+++ b/db-x86_64-linux-natipkg/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +8,5 @@
 (define pkg-desc "native libraries for \"base\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license '((Apache-2.0 OR MIT) AND blessing))

--- a/draw-aarch64-macosx-3/LICENSE.txt
+++ b/draw-aarch64-macosx-3/LICENSE.txt
@@ -1,11 +1,12 @@
 draw-aarch64-macosx-3
 
-This package is distributed under the Apache 2.0 and MIT licenses. The
-user can choose the license under which they will be using the
-software. There may be other licenses within the distribution with
-which the user must also comply.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 libffi - Copyright (c) 1996-2014  Anthony Green, Red Hat, Inc and others.
+libffi is released under the MIT license.
 
 GLib is released under the GNU Library General Public License (GNU LGPL).
 
@@ -25,7 +26,7 @@ FontConfig:
  Copyright © 2008 Danilo Šegan
  Copyright © 2012 Google, Inc.
 
-Pixman is released under the FreeType project license.
+FreeType is released under the FreeType project license.
 
 Cairo is released under the GNU Library General Public License (GNU LGPL).
 

--- a/draw-aarch64-macosx-3/info.rkt
+++ b/draw-aarch64-macosx-3/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +8,28 @@
 (define pkg-desc "native libraries for \"draw\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '((Apache-2.0 OR MIT)
+    AND
+    (MIT
+     AND
+     (LGPL-2.1-or-later
+      AND
+      (LGPL-2.0-or-later
+       AND
+       (MIT-Modern-Variant
+        AND
+        (Unicode-DFS-2016
+         AND
+         (HPND-sell-variant
+          AND
+          (FTL
+           AND
+           ((LGPL-2.1-only OR MPL-1.1)
+            AND
+            (Libpng AND (IJG AND BSD-3-clause))))))))))))
+
+;; additionally, fontconfig/src/fcmd5.h and
+;; fontconfig/src/ftglue.{c,h} are placed in the public domain
+;; using non-standardized language.

--- a/draw-aarch64-macosx-3/racket/draw/info.rkt
+++ b/draw-aarch64-macosx-3/racket/draw/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "aarch64-macosx")
 

--- a/draw-i386-macosx-2/LICENSE.txt
+++ b/draw-i386-macosx-2/LICENSE.txt
@@ -1,11 +1,14 @@
 draw-i386-macosx-2
 Copyright (c) 2010-2014 PLT Design Inc.
 
-Individual components of this package are distributed under a multiple
-licenses, including the GNU Lesser General Public License (LGPL), the
-MIT License, the FreeType license, and the libpng license.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 libffi - Copyright (c) 1996-2014  Anthony Green, Red Hat, Inc and others.
+
+libffi is released under the MIT license.
 
 GLib is released under the GNU Library General Public License (GNU LGPL).
 

--- a/draw-i386-macosx-2/info.rkt
+++ b/draw-i386-macosx-2/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +7,30 @@
 (define pkg-desc "native libraries for \"draw\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '((Apache-2.0 OR MIT) ;; Racket code
+    AND
+    (MIT ;; libffi, most of pixman, part of fontconfig
+     AND
+     (MIT-Modern-Variant ;; HarfBuzz, part of fontconfig
+      AND
+      (LGPL-2.1-or-later ;; Glib, Pango, libintl
+       AND
+       (LGPL-2.0-or-later ;; some libintl files
+        AND
+        ((LGPL-2.1-only OR MPL-1.1) ;; Cairo
+         AND
+         (HPND-sell-variant ;; fontconfig, part of pixman
+          AND
+          (Unicode-DFS-2016 ;; part of fontconfig
+           AND
+           (FTL ;; part of pixman (may have been replaced)
+            AND
+            (Libpng ;; libpng (obviously)
+             AND
+             IJG))))))))))) ;; libjpeg
+
+;; additionally, fontconfig/src/fcmd5.h and
+;; fontconfig/src/ftglue.{c,h} are placed in the public domain
+;; using non-standardized language.

--- a/draw-i386-macosx-2/racket/draw/info.rkt
+++ b/draw-i386-macosx-2/racket/draw/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 (define install-platform "i386-macosx")
 

--- a/draw-i386-macosx-3/LICENSE.txt
+++ b/draw-i386-macosx-3/LICENSE.txt
@@ -1,17 +1,18 @@
 draw-i386-macosx-3
-Copyright (c) 2010-2018 PLT Design Inc.
 
-Individual components of this package are distributed under a multiple
-licenses, including the GNU Lesser General Public License (LGPL), the
-MIT License, the FreeType license, and the libpng license.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 libffi - Copyright (c) 1996-2014  Anthony Green, Red Hat, Inc and others.
+libffi is released under the MIT license.
 
 GLib is released under the GNU Library General Public License (GNU LGPL).
 
 libintl is released under the GNU Library General Public License (GNU LGPL).
 
-HarfBuzz is relased under a MIT license.
+HarfBuzz is released under a MIT license.
 
 FriBidi is released under the GNU Library General Public License (GNU LGPL).
 
@@ -25,14 +26,14 @@ FontConfig:
  Copyright © 2008 Danilo Šegan
  Copyright © 2012 Google, Inc.
 
-Pixman is relased under the FreeType project license.
+FreeType is released under the FreeType project license.
 
 Cairo is released under the GNU Library General Public License (GNU LGPL).
 
-Pixman is relased under a MIT license.
+Pixman is released under a MIT license.
 
 Libpng is released under the libpng license.
 
 This software is based in part on the work of the Independent JPEG Group.
 
-libuuid is relased under a Modified BSD license.
+libuuid is released under a Modified BSD license.

--- a/draw-i386-macosx-3/info.rkt
+++ b/draw-i386-macosx-3/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +8,28 @@
 (define pkg-desc "native libraries for \"draw\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '((Apache-2.0 OR MIT)
+    AND
+    (MIT
+     AND
+     (LGPL-2.1-or-later
+      AND
+      (LGPL-2.0-or-later
+       AND
+       (MIT-Modern-Variant
+        AND
+        (Unicode-DFS-2016
+         AND
+         (HPND-sell-variant
+          AND
+          (FTL
+           AND
+           ((LGPL-2.1-only OR MPL-1.1)
+            AND
+            (Libpng AND (IJG AND BSD-3-clause))))))))))))
+
+;; additionally, fontconfig/src/fcmd5.h and
+;; fontconfig/src/ftglue.{c,h} are placed in the public domain
+;; using non-standardized language.

--- a/draw-i386-macosx-3/racket/draw/info.rkt
+++ b/draw-i386-macosx-3/racket/draw/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "i386-macosx")
 

--- a/draw-i386-macosx/LICENSE.txt
+++ b/draw-i386-macosx/LICENSE.txt
@@ -1,9 +1,10 @@
 draw-i386-macosx
 Copyright (c) 2010-2014 PLT Design Inc.
 
-Individual components of this package are distributed under a multiple
-licenses, including the GNU Lesser General Public License (LGPL), the
-MIT License, the FreeType license, and the libpng license.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 GLib is released under the GNU Library General Public License (GNU LGPL).
 

--- a/draw-i386-macosx/info.rkt
+++ b/draw-i386-macosx/info.rkt
@@ -1,7 +1,28 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 (define collection 'multi)
 (define deps '("base"))
 
 (define pkg-desc "native libraries for \"draw\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '((Apache-2.0 OR MIT) ;; Racket code
+    AND
+    (MIT ;; libffi, most of pixman
+     AND
+     (LGPL-2.1-or-later ;; Glib, Pango, libintl
+      AND
+      (LGPL-2.0-or-later ;; some libintl files
+       AND
+       ((LGPL-2.1-only OR MPL-1.1) ;; Cairo
+        AND
+        (HPND-sell-variant ;; part of pixman
+         AND
+         (FTL ;; part of pixman (may have been replaced)
+          AND
+          (Libpng ;; libpng (obviously)
+           AND
+           IJG))))))))) ;; libjpeg

--- a/draw-i386-macosx/racket/draw/info.rkt
+++ b/draw-i386-macosx/racket/draw/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 (define copy-foreign-libs (quote ("libcairo.2.dylib" "libffi.5.dylib" "libintl.8.dylib" "libgio-2.0.0.dylib" "libjpeg.62.dylib" "libglib-2.0.0.dylib" "libpango-1.0.0.dylib" "libgmodule-2.0.0.dylib" "libpangocairo-1.0.0.dylib" "libgobject-2.0.0.dylib" "libpixman-1.0.dylib" "libgthread-2.0.0.dylib" "libpng15.15.dylib")))
-(define collection 'multi)
 (define install-platform "i386-macosx")

--- a/draw-ppc-macosx-2/LICENSE.txt
+++ b/draw-ppc-macosx-2/LICENSE.txt
@@ -1,11 +1,14 @@
 draw-ppc-macosx-2
 Copyright (c) 2010-2014 PLT Design Inc.
 
-Individual components of this package are distributed under a multiple
-licenses, including the GNU Lesser General Public License (LGPL), the
-MIT License, the FreeType license, and the libpng license.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 libffi - Copyright (c) 1996-2014  Anthony Green, Red Hat, Inc and others.
+
+libffi is released under the MIT license.
 
 GLib is released under the GNU Library General Public License (GNU LGPL).
 

--- a/draw-ppc-macosx-2/info.rkt
+++ b/draw-ppc-macosx-2/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +7,30 @@
 (define pkg-desc "native libraries for \"draw\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '((Apache-2.0 OR MIT) ;; Racket code
+    AND
+    (MIT ;; libffi, most of pixman, part of fontconfig
+     AND
+     (MIT-Modern-Variant ;; HarfBuzz, part of fontconfig
+      AND
+      (LGPL-2.1-or-later ;; Glib, Pango, libintl
+       AND
+       (LGPL-2.0-or-later ;; some libintl files
+        AND
+        ((LGPL-2.1-only OR MPL-1.1) ;; Cairo
+         AND
+         (HPND-sell-variant ;; fontconfig, part of pixman
+          AND
+          (Unicode-DFS-2016 ;; part of fontconfig
+           AND
+           (FTL ;; part of pixman (may have been replaced)
+            AND
+            (Libpng ;; libpng (obviously)
+             AND
+             IJG))))))))))) ;; libjpeg
+
+;; additionally, fontconfig/src/fcmd5.h and
+;; fontconfig/src/ftglue.{c,h} are placed in the public domain
+;; using non-standardized language.

--- a/draw-ppc-macosx-2/racket/draw/info.rkt
+++ b/draw-ppc-macosx-2/racket/draw/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 (define install-platform "ppc-macosx")
 

--- a/draw-ppc-macosx-3/LICENSE.txt
+++ b/draw-ppc-macosx-3/LICENSE.txt
@@ -1,17 +1,18 @@
 draw-ppc-macosx-3
-Copyright (c) 2010-2018 PLT Design Inc.
 
-Individual components of this package are distributed under a multiple
-licenses, including the GNU Lesser General Public License (LGPL), the
-MIT License, the FreeType license, and the libpng license.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 libffi - Copyright (c) 1996-2014  Anthony Green, Red Hat, Inc and others.
+libffi is released under the MIT license.
 
 GLib is released under the GNU Library General Public License (GNU LGPL).
 
 libintl is released under the GNU Library General Public License (GNU LGPL).
 
-HarfBuzz is relased under a MIT license.
+HarfBuzz is released under a MIT license.
 
 FriBidi is released under the GNU Library General Public License (GNU LGPL).
 
@@ -25,14 +26,14 @@ FontConfig:
  Copyright © 2008 Danilo Šegan
  Copyright © 2012 Google, Inc.
 
-Pixman is relased under the FreeType project license.
+FreeType is released under the FreeType project license.
 
 Cairo is released under the GNU Library General Public License (GNU LGPL).
 
-Pixman is relased under a MIT license.
+Pixman is released under a MIT license.
 
 Libpng is released under the libpng license.
 
 This software is based in part on the work of the Independent JPEG Group.
 
-libuuid is relased under a Modified BSD license.
+libuuid is released under a Modified BSD license.

--- a/draw-ppc-macosx-3/info.rkt
+++ b/draw-ppc-macosx-3/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +8,28 @@
 (define pkg-desc "native libraries for \"draw\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '((Apache-2.0 OR MIT)
+    AND
+    (MIT
+     AND
+     (LGPL-2.1-or-later
+      AND
+      (LGPL-2.0-or-later
+       AND
+       (MIT-Modern-Variant
+        AND
+        (Unicode-DFS-2016
+         AND
+         (HPND-sell-variant
+          AND
+          (FTL
+           AND
+           ((LGPL-2.1-only OR MPL-1.1)
+            AND
+            (Libpng AND (IJG AND BSD-3-clause))))))))))))
+
+;; additionally, fontconfig/src/fcmd5.h and
+;; fontconfig/src/ftglue.{c,h} are placed in the public domain
+;; using non-standardized language.

--- a/draw-ppc-macosx-3/racket/draw/info.rkt
+++ b/draw-ppc-macosx-3/racket/draw/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "ppc-macosx")
 

--- a/draw-ppc-macosx/LICENSE.txt
+++ b/draw-ppc-macosx/LICENSE.txt
@@ -1,9 +1,10 @@
 draw-ppc-macosx
 Copyright (c) 2010-2014 PLT Design Inc.
 
-Individual components of this package are distributed under a multiple
-licenses, including the GNU Lesser General Public License (LGPL), the
-MIT License, the FreeType license, and the libpng license.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 GLib is released under the GNU Library General Public License (GNU LGPL).
 

--- a/draw-ppc-macosx/info.rkt
+++ b/draw-ppc-macosx/info.rkt
@@ -1,7 +1,28 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 (define collection 'multi)
 (define deps '("base"))
 
 (define pkg-desc "native libraries for \"draw\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '((Apache-2.0 OR MIT) ;; Racket code
+    AND
+    (MIT ;; libffi, most of pixman
+     AND
+     (LGPL-2.1-or-later ;; Glib, Pango, libintl
+      AND
+      (LGPL-2.0-or-later ;; some libintl files
+       AND
+       ((LGPL-2.1-only OR MPL-1.1) ;; Cairo
+        AND
+        (HPND-sell-variant ;; part of pixman
+         AND
+         (FTL ;; part of pixman (may have been replaced)
+          AND
+          (Libpng ;; libpng (obviously)
+           AND
+           IJG))))))))) ;; libjpeg

--- a/draw-ppc-macosx/racket/draw/info.rkt
+++ b/draw-ppc-macosx/racket/draw/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 (define copy-foreign-libs (quote ("libcairo.2.dylib" "libffi.5.dylib" "libintl.8.dylib" "libgio-2.0.0.dylib" "libjpeg.62.dylib" "libglib-2.0.0.dylib" "libpango-1.0.0.dylib" "libgmodule-2.0.0.dylib" "libpangocairo-1.0.0.dylib" "libgobject-2.0.0.dylib" "libpixman-1.0.dylib" "libgthread-2.0.0.dylib" "libpng15.15.dylib")))
-(define collection 'multi)
 (define install-platform "ppc-macosx")

--- a/draw-ttf-x86_64-linux-natipkg/LICENSE.txt
+++ b/draw-ttf-x86_64-linux-natipkg/LICENSE.txt
@@ -1,19 +1,32 @@
 draw-ttf-x86_64-linux-natipkg
-Copyright (c) 2010-2018 PLT Design Inc.
 
-This package is distributed under the GNU Lesser General Public
-License (LGPL).  This means that you can link this package into
-proprietary applications, provided you follow the rules stated in the
-LGPL.  You can also modify this package; if you distribute a modified
-version, you must distribute it under the terms of the LGPL, which in
-particular means that you must release the source code for the
-modified software.  See http://www.gnu.org/copyleft/lesser.html
-for more information.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
-Fonts:
- Copyright © 2000,2001,2002,2003,2004,2006,2007 Keith Packard
- Copyright © 2005 Patrick Lam
- Copyright © 2009 Roozbeh Pournader
- Copyright © 2008,2009 Red Hat, Inc.
- Copyright © 2008 Danilo Šegan
- Copyright © 2012 Google, Inc.
+GNU FreeFont
+Copyleft 2002, 2003, 2005, 2008, 2009, 2010 Free Software Foundation.
+
+Free UCS scalable fonts is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License as published
+by the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+The fonts are distributed in the hope that they will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+As a special exception, if you create a document which uses this font, and
+embed this font or unaltered portions of this font into the document, this
+font does not by itself cause the resulting document to be covered by the
+GNU General Public License. This exception does not however invalidate any
+other reasons why the document might be covered by the GNU General Public
+License. If you modify this font, you may extend this exception to your
+version of the font, but you are not obligated to do so.  If you do not
+wish to do so, delete this exception statement from your version.

--- a/draw-ttf-x86_64-linux-natipkg/info.rkt
+++ b/draw-ttf-x86_64-linux-natipkg/info.rkt
@@ -1,8 +1,13 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
 
-(define pkg-desc "native libraries for \"draw\" package")
+(define pkg-desc "shared files for \"draw\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '((Apache-2.0 OR MIT) AND (GPL-3.0-or-later WITH Font-exception-2.0)))

--- a/draw-ttf-x86_64-linux-natipkg/racket/draw/ttf/info.rkt
+++ b/draw-ttf-x86_64-linux-natipkg/racket/draw/ttf/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "x86_64-linux-natipkg")
 

--- a/draw-win32-arm64-3/LICENSE.txt
+++ b/draw-win32-arm64-3/LICENSE.txt
@@ -1,11 +1,12 @@
 draw-win32-arm64-3
 
-This package is distributed under the Apache 2.0 and MIT licenses. The
-user can choose the license under which they will be using the
-software. There may be other licenses within the distribution with
-which the user must also comply.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 libffi - Copyright (c) 1996-2014  Anthony Green, Red Hat, Inc and others.
+libffi is released under the MIT license.
 
 GLib is released under the GNU Library General Public License (GNU LGPL).
 
@@ -25,7 +26,7 @@ FontConfig:
  Copyright © 2008 Danilo Šegan
  Copyright © 2012 Google, Inc.
 
-Pixman is released under the FreeType project license.
+FreeType is released under the FreeType project license.
 
 Cairo is released under the GNU Library General Public License (GNU LGPL).
 

--- a/draw-win32-arm64-3/info.rkt
+++ b/draw-win32-arm64-3/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +8,28 @@
 (define pkg-desc "native libraries for \"draw\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '((Apache-2.0 OR MIT)
+    AND
+    (MIT
+     AND
+     (LGPL-2.1-or-later
+      AND
+      (LGPL-2.0-or-later
+       AND
+       (MIT-Modern-Variant
+        AND
+        (Unicode-DFS-2016
+         AND
+         (HPND-sell-variant
+          AND
+          (FTL
+           AND
+           ((LGPL-2.1-only OR MPL-1.1)
+            AND
+            (Libpng AND (IJG AND Zlib))))))))))))
+
+;; additionally, fontconfig/src/fcmd5.h and
+;; fontconfig/src/ftglue.{c,h} are placed in the public domain
+;; using non-standardized language.

--- a/draw-win32-arm64-3/racket/draw/info.rkt
+++ b/draw-win32-arm64-3/racket/draw/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "win32\\arm64")
 

--- a/draw-win32-i386-2/LICENSE.txt
+++ b/draw-win32-i386-2/LICENSE.txt
@@ -1,11 +1,14 @@
 draw-win32-i386-2
 Copyright (c) 2010-2014 PLT Design Inc.
 
-Individual components of this package are distributed under a multiple
-licenses, including the GNU Lesser General Public License (LGPL), the
-MIT License, the FreeType license, and the libpng license.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 libffi - Copyright (c) 1996-2014  Anthony Green, Red Hat, Inc and others.
+
+libffi is released under the MIT license.
 
 GLib is released under the GNU Library General Public License (GNU LGPL).
 

--- a/draw-win32-i386-2/info.rkt
+++ b/draw-win32-i386-2/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +7,30 @@
 (define pkg-desc "native libraries for \"draw\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '((Apache-2.0 OR MIT) ;; Racket code
+    AND
+    (MIT ;; libffi, most of pixman, part of fontconfig
+     AND
+     (MIT-Modern-Variant ;; HarfBuzz, part of fontconfig
+      AND
+      (LGPL-2.1-or-later ;; Glib, Pango, libintl
+       AND
+       (LGPL-2.0-or-later ;; some libintl files
+        AND
+        ((LGPL-2.1-only OR MPL-1.1) ;; Cairo
+         AND
+         (HPND-sell-variant ;; fontconfig, part of pixman
+          AND
+          (Unicode-DFS-2016 ;; part of fontconfig
+           AND
+           (FTL ;; part of pixman (may have been replaced)
+            AND
+            (Libpng ;; libpng (obviously)
+             AND
+             IJG))))))))))) ;; libjpeg
+
+;; additionally, fontconfig/src/fcmd5.h and
+;; fontconfig/src/ftglue.{c,h} are placed in the public domain
+;; using non-standardized language.

--- a/draw-win32-i386-2/racket/draw/info.rkt
+++ b/draw-win32-i386-2/racket/draw/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 (define install-platform "win32\\i386")
 

--- a/draw-win32-i386-3/LICENSE.txt
+++ b/draw-win32-i386-3/LICENSE.txt
@@ -1,17 +1,18 @@
 draw-win32-i386-3
-Copyright (c) 2010-2018 PLT Design Inc.
 
-Individual components of this package are distributed under a multiple
-licenses, including the GNU Lesser General Public License (LGPL), the
-MIT License, the FreeType license, and the libpng license.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 libffi - Copyright (c) 1996-2014  Anthony Green, Red Hat, Inc and others.
+libffi is released under the MIT license.
 
 GLib is released under the GNU Library General Public License (GNU LGPL).
 
 libintl is released under the GNU Library General Public License (GNU LGPL).
 
-HarfBuzz is relased under a MIT license.
+HarfBuzz is released under a MIT license.
 
 FriBidi is released under the GNU Library General Public License (GNU LGPL).
 
@@ -25,11 +26,11 @@ FontConfig:
  Copyright © 2008 Danilo Šegan
  Copyright © 2012 Google, Inc.
 
-Pixman is relased under the FreeType project license.
+FreeType is released under the FreeType project license.
 
 Cairo is released under the GNU Library General Public License (GNU LGPL).
 
-Pixman is relased under a MIT license.
+Pixman is released under a MIT license.
 
 Libpng is released under the libpng license.
 

--- a/draw-win32-i386-3/info.rkt
+++ b/draw-win32-i386-3/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +8,28 @@
 (define pkg-desc "native libraries for \"draw\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '((Apache-2.0 OR MIT)
+    AND
+    (MIT
+     AND
+     (LGPL-2.1-or-later
+      AND
+      (LGPL-2.0-or-later
+       AND
+       (MIT-Modern-Variant
+        AND
+        (Unicode-DFS-2016
+         AND
+         (HPND-sell-variant
+          AND
+          (FTL
+           AND
+           ((LGPL-2.1-only OR MPL-1.1)
+            AND
+            (Libpng AND (IJG AND Zlib))))))))))))
+
+;; additionally, fontconfig/src/fcmd5.h and
+;; fontconfig/src/ftglue.{c,h} are placed in the public domain
+;; using non-standardized language.

--- a/draw-win32-i386-3/racket/draw/info.rkt
+++ b/draw-win32-i386-3/racket/draw/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "win32\\i386")
 

--- a/draw-win32-i386/LICENSE.txt
+++ b/draw-win32-i386/LICENSE.txt
@@ -1,9 +1,10 @@
 draw-win32-i386
 Copyright (c) 2010-2014 PLT Design Inc.
 
-Individual components of this package are distributed under a multiple
-licenses, including the GNU Lesser General Public License (LGPL), the
-MIT License, the FreeType license, and the libpng license.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 GLib is released under the GNU Library General Public License (GNU LGPL).
 

--- a/draw-win32-i386/info.rkt
+++ b/draw-win32-i386/info.rkt
@@ -1,7 +1,32 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 (define collection 'multi)
 (define deps '("base"))
 
 (define pkg-desc "native libraries for \"draw\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '((Apache-2.0 OR MIT) ;; Racket code
+    AND
+    (MIT ;; part of fontconfig
+     AND
+     (MIT-Modern-Variant ;; part of fontconfig
+      AND
+      (LGPL-2.1-or-later ;; Glib, Pango
+       AND
+       ((LGPL-2.1-only OR MPL-1.1) ;; Cairo
+        AND
+        (HPND-sell-variant ;; fontconfig
+         AND
+         (Unicode-DFS-2016 ;; part of fontconfig
+          AND
+          (Libpng ;; libpng (obviously)
+           AND
+           IJG))))))))) ;; libjpeg
+
+;; additionally, fontconfig/src/fcmd5.h and
+;; fontconfig/src/ftglue.{c,h} are placed in the public domain
+;; using non-standardized language.

--- a/draw-win32-i386/racket/draw/info.rkt
+++ b/draw-win32-i386/racket/draw/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 (define copy-foreign-libs (quote ("libjpeg-7.dll" "libcairo-2.dll" "libpango-1.0-0.dll" "libexpat-1.dll" "libpng14-14.dll" "zlib1.dll" "freetype6.dll" "libfontconfig-1.dll" "libglib-2.0-0.dll" "libgobject-2.0-0.dll" "libgmodule-2.0-0.dll" "libpangocairo-1.0-0.dll" "libpangowin32-1.0-0.dll" "libpangoft2-1.0-0.dll")))
-(define collection 'multi)
 (define install-platform "win32\\i386")

--- a/draw-win32-x86_64-2/LICENSE.txt
+++ b/draw-win32-x86_64-2/LICENSE.txt
@@ -1,11 +1,14 @@
 draw-win32-x86_64-2
 Copyright (c) 2010-2014 PLT Design Inc.
 
-Individual components of this package are distributed under a multiple
-licenses, including the GNU Lesser General Public License (LGPL), the
-MIT License, the FreeType license, and the libpng license.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 libffi - Copyright (c) 1996-2014  Anthony Green, Red Hat, Inc and others.
+
+libffi is released under the MIT license.
 
 GLib is released under the GNU Library General Public License (GNU LGPL).
 

--- a/draw-win32-x86_64-2/info.rkt
+++ b/draw-win32-x86_64-2/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +7,30 @@
 (define pkg-desc "native libraries for \"draw\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '((Apache-2.0 OR MIT) ;; Racket code
+    AND
+    (MIT ;; libffi, most of pixman, part of fontconfig
+     AND
+     (MIT-Modern-Variant ;; HarfBuzz, part of fontconfig
+      AND
+      (LGPL-2.1-or-later ;; Glib, Pango, libintl
+       AND
+       (LGPL-2.0-or-later ;; some libintl files
+        AND
+        ((LGPL-2.1-only OR MPL-1.1) ;; Cairo
+         AND
+         (HPND-sell-variant ;; fontconfig, part of pixman
+          AND
+          (Unicode-DFS-2016 ;; part of fontconfig
+           AND
+           (FTL ;; part of pixman (may have been replaced)
+            AND
+            (Libpng ;; libpng (obviously)
+             AND
+             IJG))))))))))) ;; libjpeg
+
+;; additionally, fontconfig/src/fcmd5.h and
+;; fontconfig/src/ftglue.{c,h} are placed in the public domain
+;; using non-standardized language.

--- a/draw-win32-x86_64-2/racket/draw/info.rkt
+++ b/draw-win32-x86_64-2/racket/draw/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 (define install-platform "win32\\x86_64")
 

--- a/draw-win32-x86_64-3/LICENSE.txt
+++ b/draw-win32-x86_64-3/LICENSE.txt
@@ -1,17 +1,18 @@
 draw-win32-x86_64-3
-Copyright (c) 2010-2018 PLT Design Inc.
 
-Individual components of this package are distributed under a multiple
-licenses, including the GNU Lesser General Public License (LGPL), the
-MIT License, the FreeType license, and the libpng license.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 libffi - Copyright (c) 1996-2014  Anthony Green, Red Hat, Inc and others.
+libffi is released under the MIT license.
 
 GLib is released under the GNU Library General Public License (GNU LGPL).
 
 libintl is released under the GNU Library General Public License (GNU LGPL).
 
-HarfBuzz is relased under a MIT license.
+HarfBuzz is released under a MIT license.
 
 FriBidi is released under the GNU Library General Public License (GNU LGPL).
 
@@ -25,11 +26,11 @@ FontConfig:
  Copyright © 2008 Danilo Šegan
  Copyright © 2012 Google, Inc.
 
-Pixman is relased under the FreeType project license.
+FreeType is released under the FreeType project license.
 
 Cairo is released under the GNU Library General Public License (GNU LGPL).
 
-Pixman is relased under a MIT license.
+Pixman is released under a MIT license.
 
 Libpng is released under the libpng license.
 

--- a/draw-win32-x86_64-3/info.rkt
+++ b/draw-win32-x86_64-3/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +8,28 @@
 (define pkg-desc "native libraries for \"draw\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '((Apache-2.0 OR MIT)
+    AND
+    (MIT
+     AND
+     (LGPL-2.1-or-later
+      AND
+      (LGPL-2.0-or-later
+       AND
+       (MIT-Modern-Variant
+        AND
+        (Unicode-DFS-2016
+         AND
+         (HPND-sell-variant
+          AND
+          (FTL
+           AND
+           ((LGPL-2.1-only OR MPL-1.1)
+            AND
+            (Libpng AND (IJG AND Zlib))))))))))))
+
+;; additionally, fontconfig/src/fcmd5.h and
+;; fontconfig/src/ftglue.{c,h} are placed in the public domain
+;; using non-standardized language.

--- a/draw-win32-x86_64-3/racket/draw/info.rkt
+++ b/draw-win32-x86_64-3/racket/draw/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "win32\\x86_64")
 

--- a/draw-win32-x86_64/LICENSE.txt
+++ b/draw-win32-x86_64/LICENSE.txt
@@ -1,9 +1,10 @@
 draw-win32-x86_64
 Copyright (c) 2010-2014 PLT Design Inc.
 
-Individual components of this package are distributed under a multiple
-licenses, including the GNU Lesser General Public License (LGPL), the
-MIT License, the FreeType license, and the libpng license.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 GLib is released under the GNU Library General Public License (GNU LGPL).
 

--- a/draw-win32-x86_64/info.rkt
+++ b/draw-win32-x86_64/info.rkt
@@ -1,7 +1,34 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 (define collection 'multi)
 (define deps '("base"))
 
 (define pkg-desc "native libraries for \"draw\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '((Apache-2.0 OR MIT) ;; Racket code
+    AND
+    (MIT ;; part of fontconfig
+     AND
+     (MIT-Modern-Variant ;; part of fontconfig
+      AND
+      (LGPL-2.1-or-later ;; Glib, Pango, libintl
+       AND
+       (LGPL-2.0-or-later ;; some libintl files
+        AND
+        ((LGPL-2.1-only OR MPL-1.1) ;; Cairo
+         AND
+         (HPND-sell-variant ;; fontconfig
+          AND
+          (Unicode-DFS-2016 ;; part of fontconfig
+           AND
+           (Libpng ;; libpng (obviously)
+            AND
+            IJG)))))))))) ;; libjpeg
+
+;; additionally, fontconfig/src/fcmd5.h and
+;; fontconfig/src/ftglue.{c,h} are placed in the public domain
+;; using non-standardized language.

--- a/draw-win32-x86_64/racket/draw/info.rkt
+++ b/draw-win32-x86_64/racket/draw/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 (define copy-foreign-libs (quote ("libjpeg-8.dll" "libcairo-2.dll" "libpango-1.0-0.dll" "libexpat-1.dll" "libpng14-14.dll" "zlib1.dll" "libfreetype-6.dll" "libintl-8.dll" "libfontconfig-1.dll" "libglib-2.0-0.dll" "libgobject-2.0-0.dll" "libgmodule-2.0-0.dll" "libgthread-2.0-0.dll" "libpangocairo-1.0-0.dll" "libpangowin32-1.0-0.dll" "libpangoft2-1.0-0.dll")))
-(define collection 'multi)
 (define install-platform "win32\\x86_64")

--- a/draw-x11-x86_64-linux-natipkg/LICENSE.txt
+++ b/draw-x11-x86_64-linux-natipkg/LICENSE.txt
@@ -1,10 +1,9 @@
 draw-x11-x86_64-linux-natipkg
-Copyright (c) 2010-2018 PLT Design Inc.
 
-This package is distributed under the Apache 2.0 and MIT licenses. The
-user can choose the license under which they will be using the
-software. There may be other licenses within the distribution with
-which the user must also comply.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 libXau - Copyright 1988, 1993, 1994, 1998  The Open Group
 

--- a/draw-x11-x86_64-linux-natipkg/info.rkt
+++ b/draw-x11-x86_64-linux-natipkg/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +8,5 @@
 (define pkg-desc "native libraries for \"draw\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license '((Apache-2.0 OR MIT) AND X11))

--- a/draw-x11-x86_64-linux-natipkg/racket/draw/x11/info.rkt
+++ b/draw-x11-x86_64-linux-natipkg/racket/draw/x11/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "x86_64-linux-natipkg")
 

--- a/draw-x86_64-linux-natipkg-2/LICENSE.txt
+++ b/draw-x86_64-linux-natipkg-2/LICENSE.txt
@@ -1,11 +1,14 @@
 draw-x86_64-linux-natipkg-2
 Copyright (c) 2010-2014 PLT Design Inc.
 
-Individual components of this package are distributed under a multiple
-licenses, including the GNU Lesser General Public License (LGPL), the
-MIT License, the FreeType license, and the libpng license.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 libffi - Copyright (c) 1996-2014  Anthony Green, Red Hat, Inc and others.
+
+libffi is released under the MIT license.
 
 GLib is released under the GNU Library General Public License (GNU LGPL).
 

--- a/draw-x86_64-linux-natipkg-2/info.rkt
+++ b/draw-x86_64-linux-natipkg-2/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +7,30 @@
 (define pkg-desc "native libraries for \"draw\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '((Apache-2.0 OR MIT) ;; Racket code
+    AND
+    (MIT ;; libffi, most of pixman, part of fontconfig
+     AND
+     (MIT-Modern-Variant ;; HarfBuzz, part of fontconfig
+      AND
+      (LGPL-2.1-or-later ;; Glib, Pango, libintl
+       AND
+       (LGPL-2.0-or-later ;; some libintl files
+        AND
+        ((LGPL-2.1-only OR MPL-1.1) ;; Cairo
+         AND
+         (HPND-sell-variant ;; fontconfig, part of pixman
+          AND
+          (Unicode-DFS-2016 ;; part of fontconfig
+           AND
+           (FTL ;; part of pixman (may have been replaced)
+            AND
+            (Libpng ;; libpng (obviously)
+             AND
+             IJG))))))))))) ;; libjpeg
+
+;; additionally, fontconfig/src/fcmd5.h and
+;; fontconfig/src/ftglue.{c,h} are placed in the public domain
+;; using non-standardized language.

--- a/draw-x86_64-linux-natipkg-2/racket/draw/info.rkt
+++ b/draw-x86_64-linux-natipkg-2/racket/draw/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 (define install-platform "x86_64-linux-natipkg")
 

--- a/draw-x86_64-linux-natipkg-3/LICENSE.txt
+++ b/draw-x86_64-linux-natipkg-3/LICENSE.txt
@@ -1,15 +1,16 @@
 draw-x86_64-linux-natipkg-3
-Copyright (c) 2010-2018 PLT Design Inc.
 
-Individual components of this package are distributed under a multiple
-licenses, including the GNU Lesser General Public License (LGPL), the
-MIT License, the FreeType license, and the libpng license.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 libffi - Copyright (c) 1996-2014  Anthony Green, Red Hat, Inc and others.
+libffi is released under the MIT license.
 
 GLib is released under the GNU Library General Public License (GNU LGPL).
 
-HarfBuzz is relased under a MIT license.
+HarfBuzz is released under a MIT license.
 
 FriBidi is released under the GNU Library General Public License (GNU LGPL).
 
@@ -23,16 +24,16 @@ FontConfig:
  Copyright © 2008 Danilo Šegan
  Copyright © 2012 Google, Inc.
 
-Pixman is relased under the FreeType project license.
+FreeType is released under the FreeType project license.
 
 Cairo is released under the GNU Library General Public License (GNU LGPL).
 
-Pixman is relased under a MIT license.
+Pixman is released under a MIT license.
 
 Libpng is released under the libpng license.
 
 This software is based in part on the work of the Independent JPEG Group.
 
-libuuid is relased under a Modified BSD license.
+libuuid is released under a Modified BSD license.
 
 zlib is by Jean-loup Gailly and Mark Adler.

--- a/draw-x86_64-linux-natipkg-3/info.rkt
+++ b/draw-x86_64-linux-natipkg-3/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +8,26 @@
 (define pkg-desc "native libraries for \"draw\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '((Apache-2.0 OR MIT)
+    AND
+    (MIT
+     AND
+     (LGPL-2.1-or-later
+      AND
+      (MIT-Modern-Variant
+       AND
+       (Unicode-DFS-2016
+        AND
+        (HPND-sell-variant
+         AND
+         (FTL
+          AND
+          ((LGPL-2.1-only OR MPL-1.1)
+           AND
+           (Libpng AND (IJG AND (BSD-3-clause AND Zlib))))))))))))
+
+;; additionally, fontconfig/src/fcmd5.h and
+;; fontconfig/src/ftglue.{c,h} are placed in the public domain
+;; using non-standardized language.

--- a/draw-x86_64-linux-natipkg-3/racket/draw/info.rkt
+++ b/draw-x86_64-linux-natipkg-3/racket/draw/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "x86_64-linux-natipkg")
 

--- a/draw-x86_64-macosx-2/LICENSE.txt
+++ b/draw-x86_64-macosx-2/LICENSE.txt
@@ -1,11 +1,14 @@
 draw-x86_64-macosx-2
 Copyright (c) 2010-2014 PLT Design Inc.
 
-Individual components of this package are distributed under a multiple
-licenses, including the GNU Lesser General Public License (LGPL), the
-MIT License, the FreeType license, and the libpng license.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 libffi - Copyright (c) 1996-2014  Anthony Green, Red Hat, Inc and others.
+
+libffi is released under the MIT license.
 
 GLib is released under the GNU Library General Public License (GNU LGPL).
 

--- a/draw-x86_64-macosx-2/info.rkt
+++ b/draw-x86_64-macosx-2/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +7,30 @@
 (define pkg-desc "native libraries for \"draw\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '((Apache-2.0 OR MIT) ;; Racket code
+    AND
+    (MIT ;; libffi, most of pixman, part of fontconfig
+     AND
+     (MIT-Modern-Variant ;; HarfBuzz, part of fontconfig
+      AND
+      (LGPL-2.1-or-later ;; Glib, Pango, libintl
+       AND
+       (LGPL-2.0-or-later ;; some libintl files
+        AND
+        ((LGPL-2.1-only OR MPL-1.1) ;; Cairo
+         AND
+         (HPND-sell-variant ;; fontconfig, part of pixman
+          AND
+          (Unicode-DFS-2016 ;; part of fontconfig
+           AND
+           (FTL ;; part of pixman (may have been replaced)
+            AND
+            (Libpng ;; libpng (obviously)
+             AND
+             IJG))))))))))) ;; libjpeg
+
+;; additionally, fontconfig/src/fcmd5.h and
+;; fontconfig/src/ftglue.{c,h} are placed in the public domain
+;; using non-standardized language.

--- a/draw-x86_64-macosx-2/racket/draw/info.rkt
+++ b/draw-x86_64-macosx-2/racket/draw/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 (define install-platform "x86_64-macosx")
 

--- a/draw-x86_64-macosx-3/LICENSE.txt
+++ b/draw-x86_64-macosx-3/LICENSE.txt
@@ -1,11 +1,12 @@
 draw-x86_64-macosx-3
 
-This package is distributed under the Apache 2.0 and MIT licenses. The
-user can choose the license under which they will be using the
-software. There may be other licenses within the distribution with
-which the user must also comply.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 libffi - Copyright (c) 1996-2014  Anthony Green, Red Hat, Inc and others.
+libffi is released under the MIT license.
 
 GLib is released under the GNU Library General Public License (GNU LGPL).
 
@@ -25,7 +26,7 @@ FontConfig:
  Copyright © 2008 Danilo Šegan
  Copyright © 2012 Google, Inc.
 
-Pixman is released under the FreeType project license.
+FreeType is released under the FreeType project license.
 
 Cairo is released under the GNU Library General Public License (GNU LGPL).
 

--- a/draw-x86_64-macosx-3/info.rkt
+++ b/draw-x86_64-macosx-3/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +8,28 @@
 (define pkg-desc "native libraries for \"draw\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '((Apache-2.0 OR MIT)
+    AND
+    (MIT
+     AND
+     (LGPL-2.1-or-later
+      AND
+      (LGPL-2.0-or-later
+       AND
+       (MIT-Modern-Variant
+        AND
+        (Unicode-DFS-2016
+         AND
+         (HPND-sell-variant
+          AND
+          (FTL
+           AND
+           ((LGPL-2.1-only OR MPL-1.1)
+            AND
+            (Libpng AND (IJG AND BSD-3-clause))))))))))))
+
+;; additionally, fontconfig/src/fcmd5.h and
+;; fontconfig/src/ftglue.{c,h} are placed in the public domain
+;; using non-standardized language.

--- a/draw-x86_64-macosx-3/racket/draw/info.rkt
+++ b/draw-x86_64-macosx-3/racket/draw/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "x86_64-macosx")
 

--- a/draw-x86_64-macosx/LICENSE.txt
+++ b/draw-x86_64-macosx/LICENSE.txt
@@ -1,9 +1,10 @@
 draw-x86_64-macosx
 Copyright (c) 2010-2014 PLT Design Inc.
 
-Individual components of this package are distributed under a multiple
-licenses, including the GNU Lesser General Public License (LGPL), the
-MIT License, the FreeType license, and the libpng license.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 GLib is released under the GNU Library General Public License (GNU LGPL).
 

--- a/draw-x86_64-macosx/info.rkt
+++ b/draw-x86_64-macosx/info.rkt
@@ -1,7 +1,28 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 (define collection 'multi)
 (define deps '("base"))
 
 (define pkg-desc "native libraries for \"draw\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '((Apache-2.0 OR MIT) ;; Racket code
+    AND
+    (MIT ;; libffi, most of pixman
+     AND
+     (LGPL-2.1-or-later ;; Glib, Pango, libintl
+      AND
+      (LGPL-2.0-or-later ;; some libintl files
+       AND
+       ((LGPL-2.1-only OR MPL-1.1) ;; Cairo
+        AND
+        (HPND-sell-variant ;; part of pixman
+         AND
+         (FTL ;; part of pixman (may have been replaced)
+          AND
+          (Libpng ;; libpng (obviously)
+           AND
+           IJG))))))))) ;; libjpeg

--- a/draw-x86_64-macosx/racket/draw/info.rkt
+++ b/draw-x86_64-macosx/racket/draw/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 (define copy-foreign-libs (quote ("libcairo.2.dylib" "libffi.5.dylib" "libintl.8.dylib" "libgio-2.0.0.dylib" "libjpeg.62.dylib" "libglib-2.0.0.dylib" "libpango-1.0.0.dylib" "libgmodule-2.0.0.dylib" "libpangocairo-1.0.0.dylib" "libgobject-2.0.0.dylib" "libpixman-1.0.dylib" "libgthread-2.0.0.dylib" "libpng15.15.dylib")))
-(define collection 'multi)
 (define install-platform "x86_64-macosx")

--- a/gui-aarch64-macosx/LICENSE.txt
+++ b/gui-aarch64-macosx/LICENSE.txt
@@ -1,11 +1,11 @@
 gui-aarch64-macosx
 
-This package is distributed under the Apache 2.0 and MIT licenses. The
-user can choose the license under which they will be using the
-software. There may be other licenses within the distribution with
-which the user must also comply.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 ATK is released under the GNU Library General Public License (GNU LGPL).
 
 MMTabBarView is BSD licensed.
-See: http://mimo42.github.io/MMTabBarView/
+See: https://mimo42.github.io/MMTabBarView/

--- a/gui-aarch64-macosx/info.rkt
+++ b/gui-aarch64-macosx/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
@@ -8,3 +10,6 @@
 (define pkg-authors '(mflatt))
 
 (define version "1.3")
+
+(define license
+  '((Apache-2.0 OR MIT) AND (LGPL-2.1-or-later AND BSD-3-clause)))

--- a/gui-aarch64-macosx/racket/gui/info.rkt
+++ b/gui-aarch64-macosx/racket/gui/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "aarch64-macosx")
 

--- a/gui-i386-macosx/LICENSE.txt
+++ b/gui-i386-macosx/LICENSE.txt
@@ -1,9 +1,9 @@
 gui-i386-macosx
-Copyright (c) 2010-2018 PLT Design Inc.
 
-Individual components of this package are distributed under a multiple
-licenses, including the GNU Lesser General Public License (LGPL) and
-the BSD license.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 ATK is released under the GNU Library General Public License (GNU LGPL).
 

--- a/gui-i386-macosx/info.rkt
+++ b/gui-i386-macosx/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
@@ -7,4 +9,7 @@
 
 (define pkg-authors '(mflatt))
 
-(define version "1.2")
+(define version "1.3")
+
+(define license
+  '((Apache-2.0 OR MIT) AND (LGPL-2.1-or-later AND BSD-3-clause)))

--- a/gui-i386-macosx/racket/gui/info.rkt
+++ b/gui-i386-macosx/racket/gui/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "i386-macosx")
 

--- a/gui-ppc-macosx/LICENSE.txt
+++ b/gui-ppc-macosx/LICENSE.txt
@@ -1,9 +1,9 @@
 gui-ppc-macosx
-Copyright (c) 2010-2018 PLT Design Inc.
 
-Individual components of this package are distributed under a multiple
-licenses, including the GNU Lesser General Public License (LGPL) and
-the BSD license.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 ATK is released under the GNU Library General Public License (GNU LGPL).
 

--- a/gui-ppc-macosx/info.rkt
+++ b/gui-ppc-macosx/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
@@ -7,4 +9,7 @@
 
 (define pkg-authors '(mflatt))
 
-(define version "1.2")
+(define version "1.3")
+
+(define license
+  '((Apache-2.0 OR MIT) AND (LGPL-2.1-or-later AND BSD-3-clause)))

--- a/gui-ppc-macosx/racket/gui/info.rkt
+++ b/gui-ppc-macosx/racket/gui/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "ppc-macosx")
 

--- a/gui-win32-arm64/LICENSE.txt
+++ b/gui-win32-arm64/LICENSE.txt
@@ -1,8 +1,8 @@
 gui-win32-arm64
 
-This package is distributed under the Apache 2.0 and MIT licenses. The
-user can choose the license under which they will be using the
-software. There may be other licenses within the distribution with
-which the user must also comply.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 ATK is released under the GNU Library General Public License (GNU LGPL).

--- a/gui-win32-arm64/info.rkt
+++ b/gui-win32-arm64/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
@@ -8,3 +10,5 @@
 (define pkg-authors '(mflatt))
 
 (define version "1.3")
+
+(define license '((Apache-2.0 OR MIT) AND LGPL-2.1-or-later))

--- a/gui-win32-arm64/racket/gui/info.rkt
+++ b/gui-win32-arm64/racket/gui/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "win32\\arm64")
 

--- a/gui-win32-i386/LICENSE.txt
+++ b/gui-win32-i386/LICENSE.txt
@@ -1,13 +1,8 @@
 gui-win32-i386
-Copyright (c) 2010-2018 PLT Design Inc.
 
-This package is distributed under the GNU Lesser General Public
-License (LGPL).  This means that you can link this package into
-proprietary applications, provided you follow the rules stated in the
-LGPL.  You can also modify this package; if you distribute a modified
-version, you must distribute it under the terms of the LGPL, which in
-particular means that you must release the source code for the
-modified software.  See http://www.gnu.org/copyleft/lesser.html
-for more information.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 ATK is released under the GNU Library General Public License (GNU LGPL).

--- a/gui-win32-i386/info.rkt
+++ b/gui-win32-i386/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
@@ -7,4 +9,6 @@
 
 (define pkg-authors '(mflatt))
 
-(define version "1.2")
+(define version "1.3")
+
+(define license '((Apache-2.0 OR MIT) AND LGPL-2.1-or-later))

--- a/gui-win32-i386/racket/gui/info.rkt
+++ b/gui-win32-i386/racket/gui/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "win32\\i386")
 

--- a/gui-win32-x86_64/LICENSE.txt
+++ b/gui-win32-x86_64/LICENSE.txt
@@ -1,13 +1,8 @@
 gui-win32-x86_64
-Copyright (c) 2010-2018 PLT Design Inc.
 
-This package is distributed under the GNU Lesser General Public
-License (LGPL).  This means that you can link this package into
-proprietary applications, provided you follow the rules stated in the
-LGPL.  You can also modify this package; if you distribute a modified
-version, you must distribute it under the terms of the LGPL, which in
-particular means that you must release the source code for the
-modified software.  See http://www.gnu.org/copyleft/lesser.html
-for more information.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 ATK is released under the GNU Library General Public License (GNU LGPL).

--- a/gui-win32-x86_64/info.rkt
+++ b/gui-win32-x86_64/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
@@ -7,4 +9,6 @@
 
 (define pkg-authors '(mflatt))
 
-(define version "1.2")
+(define version "1.3")
+
+(define license '((Apache-2.0 OR MIT) AND LGPL-2.1-or-later))

--- a/gui-win32-x86_64/racket/gui/info.rkt
+++ b/gui-win32-x86_64/racket/gui/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "win32\\x86_64")
 

--- a/gui-x86_64-linux-natipkg/LICENSE.txt
+++ b/gui-x86_64-linux-natipkg/LICENSE.txt
@@ -1,15 +1,10 @@
 gui-x86_64-linux-natipkg
-Copyright (c) 2010-2014 PLT Design Inc.
 
-This package is distributed under the GNU Lesser General Public
-License (LGPL).  This means that you can link this package into
-proprietary applications, provided you follow the rules stated in the
-LGPL.  You can also modify this package; if you distribute a modified
-version, you must distribute it under the terms of the LGPL, which in
-particular means that you must release the source code for the
-modified software.  See http://www.gnu.org/copyleft/lesser.html
-for more information.
-
-GTK+ is released under the GNU Library General Public License (GNU LGPL).
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 ATK is released under the GNU Library General Public License (GNU LGPL).
+
+GTK+ is released under the GNU Library General Public License (GNU LGPL).

--- a/gui-x86_64-linux-natipkg/info.rkt
+++ b/gui-x86_64-linux-natipkg/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +8,7 @@
 (define pkg-desc "native libraries for \"gui\" package")
 
 (define pkg-authors '(mflatt))
+
+(define version "1.3")
+
+(define license '((Apache-2.0 OR MIT) AND LGPL-2.1-or-later))

--- a/gui-x86_64-linux-natipkg/racket/gui/info.rkt
+++ b/gui-x86_64-linux-natipkg/racket/gui/info.rkt
@@ -1,9 +1,11 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "x86_64-linux-natipkg")
 
 (define copy-foreign-libs
   '("libgdk_pixbuf-2.0.so.0"
-    "libatk-1.0.so.0"
     "libgdk-x11-2.0.so.0"
-    "libgtk-x11-2.0.so.0"))
+    "libgtk-x11-2.0.so.0"
+    "libatk-1.0.so.0"))

--- a/gui-x86_64-macosx/LICENSE.txt
+++ b/gui-x86_64-macosx/LICENSE.txt
@@ -1,14 +1,14 @@
 gui-x86_64-macosx
 
-This package is distributed under the Apache 2.0 and MIT licenses. The
-user can choose the license under which they will be using the
-software. There may be other licenses within the distribution with
-which the user must also comply.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 ATK is released under the GNU Library General Public License (GNU LGPL).
 
+MMTabBarView is BSD licensed.
+See: https://mimo42.github.io/MMTabBarView/
+
 PSMTabBarControl is BSD licensed.
 See: http://www.positivespinmedia.com/dev/PSMTabBarControl.html
-
-MMTabBarView is BSD licensed.
-See: http://mimo42.github.io/MMTabBarView/

--- a/gui-x86_64-macosx/info.rkt
+++ b/gui-x86_64-macosx/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
@@ -8,3 +10,6 @@
 (define pkg-authors '(mflatt))
 
 (define version "1.3")
+
+(define license
+  '((Apache-2.0 OR MIT) AND (LGPL-2.1-or-later AND BSD-3-clause)))

--- a/gui-x86_64-macosx/racket/gui/info.rkt
+++ b/gui-x86_64-macosx/racket/gui/info.rkt
@@ -1,11 +1,13 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "x86_64-macosx")
 
 (define copy-foreign-libs
-  '("MMTabBarView.framework"
-    "PSMTabBarControl.framework"
+  '("PSMTabBarControl.framework"
+    "MMTabBarView.framework"
     "libatk-1.0.0.dylib"))
 
 (define compile-omit-paths
-  '("MMTabBarView.framework" "PSMTabBarControl.framework"))
+  '("PSMTabBarControl.framework" "MMTabBarView.framework"))

--- a/math-aarch64-macosx/LICENSE.txt
+++ b/math-aarch64-macosx/LICENSE.txt
@@ -1,10 +1,15 @@
 math-aarch64-macosx
 
-This package is distributed under the Apache 2.0 and MIT licenses. The
-user can choose the license under which they will be using the
-software. There may be other licenses within the distribution with
-which the user must also comply.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
-GNU MP is released under the GNU Lesser General Public License (GNU LGPL).
+GNU MP is dual licensed under under the conditions of the GNU Lesser
+General Public License (LGPL), version 3, or the GNU General Public
+License (GPL), version 2. This is the recipient’s choice, and the
+recipient also has the additional option of applying later versions of
+these licenses.
 
-MPFR is released under the GNU Lesser General Public License (GNU LGPL).
+MPFR is released under the GNU Lesser General Public License (GNU LGPL),
+either version 3 of the license, or (at your option) any later version.

--- a/math-aarch64-macosx/info.rkt
+++ b/math-aarch64-macosx/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +8,8 @@
 (define pkg-desc "native libraries for \"math\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '((Apache-2.0 OR MIT)
+    AND
+    ((LGPL-3.0-or-later OR GPL-2.0-or-later) AND LGPL-3.0-or-later)))

--- a/math-aarch64-macosx/math/info.rkt
+++ b/math-aarch64-macosx/math/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "aarch64-macosx")
 

--- a/math-i386-macosx/LICENSE.txt
+++ b/math-i386-macosx/LICENSE.txt
@@ -1,15 +1,15 @@
 math-i386-macosx
-Copyright (c) 2010-2018 PLT Design Inc.
 
-This package is distributed under the GNU Lesser General Public
-License (LGPL).  This means that you can link this package into
-proprietary applications, provided you follow the rules stated in the
-LGPL.  You can also modify this package; if you distribute a modified
-version, you must distribute it under the terms of the LGPL, which in
-particular means that you must release the source code for the
-modified software.  See http://www.gnu.org/copyleft/lesser.html
-for more information.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
-GNU MP is released under the GNU Lesser General Public License (GNU LGPL).
+GNU MP is dual licensed under under the conditions of the GNU Lesser
+General Public License (LGPL), version 3, or the GNU General Public
+License (GPL), version 2. This is the recipient’s choice, and the
+recipient also has the additional option of applying later versions of
+these licenses.
 
-MPFR is released under the GNU Lesser General Public License (GNU LGPL).
+MPFR is released under the GNU Lesser General Public License (GNU LGPL),
+either version 3 of the license, or (at your option) any later version.

--- a/math-i386-macosx/info.rkt
+++ b/math-i386-macosx/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +8,8 @@
 (define pkg-desc "native libraries for \"math\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '((Apache-2.0 OR MIT)
+    AND
+    ((LGPL-3.0-or-later OR GPL-2.0-or-later) AND LGPL-3.0-or-later)))

--- a/math-i386-macosx/math/info.rkt
+++ b/math-i386-macosx/math/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "i386-macosx")
 

--- a/math-ppc-macosx/LICENSE.txt
+++ b/math-ppc-macosx/LICENSE.txt
@@ -1,15 +1,15 @@
 math-ppc-macosx
-Copyright (c) 2010-2018 PLT Design Inc.
 
-This package is distributed under the GNU Lesser General Public
-License (LGPL).  This means that you can link this package into
-proprietary applications, provided you follow the rules stated in the
-LGPL.  You can also modify this package; if you distribute a modified
-version, you must distribute it under the terms of the LGPL, which in
-particular means that you must release the source code for the
-modified software.  See http://www.gnu.org/copyleft/lesser.html
-for more information.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
-GNU MP is released under the GNU Lesser General Public License (GNU LGPL).
+GNU MP is dual licensed under under the conditions of the GNU Lesser
+General Public License (LGPL), version 3, or the GNU General Public
+License (GPL), version 2. This is the recipient’s choice, and the
+recipient also has the additional option of applying later versions of
+these licenses.
 
-MPFR is released under the GNU Lesser General Public License (GNU LGPL).
+MPFR is released under the GNU Lesser General Public License (GNU LGPL),
+either version 3 of the license, or (at your option) any later version.

--- a/math-ppc-macosx/info.rkt
+++ b/math-ppc-macosx/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +8,8 @@
 (define pkg-desc "native libraries for \"math\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '((Apache-2.0 OR MIT)
+    AND
+    ((LGPL-3.0-or-later OR GPL-2.0-or-later) AND LGPL-3.0-or-later)))

--- a/math-ppc-macosx/math/info.rkt
+++ b/math-ppc-macosx/math/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "ppc-macosx")
 

--- a/math-win32-arm64/LICENSE.txt
+++ b/math-win32-arm64/LICENSE.txt
@@ -1,10 +1,15 @@
 math-win32-arm64
 
-This package is distributed under the Apache 2.0 and MIT licenses. The
-user can choose the license under which they will be using the
-software. There may be other licenses within the distribution with
-which the user must also comply.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
-GNU MP is released under the GNU Lesser General Public License (GNU LGPL).
+GNU MP is dual licensed under under the conditions of the GNU Lesser
+General Public License (LGPL), version 3, or the GNU General Public
+License (GPL), version 2. This is the recipient’s choice, and the
+recipient also has the additional option of applying later versions of
+these licenses.
 
-MPFR is released under the GNU Lesser General Public License (GNU LGPL).
+MPFR is released under the GNU Lesser General Public License (GNU LGPL),
+either version 3 of the license, or (at your option) any later version.

--- a/math-win32-arm64/info.rkt
+++ b/math-win32-arm64/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +8,8 @@
 (define pkg-desc "native libraries for \"math\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '((Apache-2.0 OR MIT)
+    AND
+    ((LGPL-3.0-or-later OR GPL-2.0-or-later) AND LGPL-3.0-or-later)))

--- a/math-win32-arm64/math/info.rkt
+++ b/math-win32-arm64/math/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "win32\\arm64")
 

--- a/math-win32-i386/LICENSE.txt
+++ b/math-win32-i386/LICENSE.txt
@@ -1,15 +1,15 @@
 math-win32-i386
-Copyright (c) 2010-2018 PLT Design Inc.
 
-This package is distributed under the GNU Lesser General Public
-License (LGPL).  This means that you can link this package into
-proprietary applications, provided you follow the rules stated in the
-LGPL.  You can also modify this package; if you distribute a modified
-version, you must distribute it under the terms of the LGPL, which in
-particular means that you must release the source code for the
-modified software.  See http://www.gnu.org/copyleft/lesser.html
-for more information.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
-GNU MP is released under the GNU Lesser General Public License (GNU LGPL).
+GNU MP is dual licensed under under the conditions of the GNU Lesser
+General Public License (LGPL), version 3, or the GNU General Public
+License (GPL), version 2. This is the recipient’s choice, and the
+recipient also has the additional option of applying later versions of
+these licenses.
 
-MPFR is released under the GNU Lesser General Public License (GNU LGPL).
+MPFR is released under the GNU Lesser General Public License (GNU LGPL),
+either version 3 of the license, or (at your option) any later version.

--- a/math-win32-i386/info.rkt
+++ b/math-win32-i386/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +8,8 @@
 (define pkg-desc "native libraries for \"math\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '((Apache-2.0 OR MIT)
+    AND
+    ((LGPL-3.0-or-later OR GPL-2.0-or-later) AND LGPL-3.0-or-later)))

--- a/math-win32-i386/math/info.rkt
+++ b/math-win32-i386/math/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "win32\\i386")
 

--- a/math-win32-x86_64/LICENSE.txt
+++ b/math-win32-x86_64/LICENSE.txt
@@ -1,15 +1,15 @@
 math-win32-x86_64
-Copyright (c) 2010-2018 PLT Design Inc.
 
-This package is distributed under the GNU Lesser General Public
-License (LGPL).  This means that you can link this package into
-proprietary applications, provided you follow the rules stated in the
-LGPL.  You can also modify this package; if you distribute a modified
-version, you must distribute it under the terms of the LGPL, which in
-particular means that you must release the source code for the
-modified software.  See http://www.gnu.org/copyleft/lesser.html
-for more information.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
-GNU MP is released under the GNU Lesser General Public License (GNU LGPL).
+GNU MP is dual licensed under under the conditions of the GNU Lesser
+General Public License (LGPL), version 3, or the GNU General Public
+License (GPL), version 2. This is the recipient’s choice, and the
+recipient also has the additional option of applying later versions of
+these licenses.
 
-MPFR is released under the GNU Lesser General Public License (GNU LGPL).
+MPFR is released under the GNU Lesser General Public License (GNU LGPL),
+either version 3 of the license, or (at your option) any later version.

--- a/math-win32-x86_64/info.rkt
+++ b/math-win32-x86_64/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +8,8 @@
 (define pkg-desc "native libraries for \"math\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '((Apache-2.0 OR MIT)
+    AND
+    ((LGPL-3.0-or-later OR GPL-2.0-or-later) AND LGPL-3.0-or-later)))

--- a/math-win32-x86_64/math/info.rkt
+++ b/math-win32-x86_64/math/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "win32\\x86_64")
 

--- a/math-x86_64-linux-natipkg/LICENSE.txt
+++ b/math-x86_64-linux-natipkg/LICENSE.txt
@@ -1,15 +1,15 @@
 math-x86_64-linux-natipkg
-Copyright (c) 2010-2018 PLT Design Inc.
 
-This package is distributed under the GNU Lesser General Public
-License (LGPL).  This means that you can link this package into
-proprietary applications, provided you follow the rules stated in the
-LGPL.  You can also modify this package; if you distribute a modified
-version, you must distribute it under the terms of the LGPL, which in
-particular means that you must release the source code for the
-modified software.  See http://www.gnu.org/copyleft/lesser.html
-for more information.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
-GNU MP is released under the GNU Lesser General Public License (GNU LGPL).
+GNU MP is dual licensed under under the conditions of the GNU Lesser
+General Public License (LGPL), version 3, or the GNU General Public
+License (GPL), version 2. This is the recipient’s choice, and the
+recipient also has the additional option of applying later versions of
+these licenses.
 
-MPFR is released under the GNU Lesser General Public License (GNU LGPL).
+MPFR is released under the GNU Lesser General Public License (GNU LGPL),
+either version 3 of the license, or (at your option) any later version.

--- a/math-x86_64-linux-natipkg/info.rkt
+++ b/math-x86_64-linux-natipkg/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +8,8 @@
 (define pkg-desc "native libraries for \"math\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '((Apache-2.0 OR MIT)
+    AND
+    ((LGPL-3.0-or-later OR GPL-2.0-or-later) AND LGPL-3.0-or-later)))

--- a/math-x86_64-linux-natipkg/math/info.rkt
+++ b/math-x86_64-linux-natipkg/math/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "x86_64-linux-natipkg")
 

--- a/math-x86_64-macosx/LICENSE.txt
+++ b/math-x86_64-macosx/LICENSE.txt
@@ -1,10 +1,15 @@
 math-x86_64-macosx
 
-This package is distributed under the Apache 2.0 and MIT licenses. The
-user can choose the license under which they will be using the
-software. There may be other licenses within the distribution with
-which the user must also comply.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
-GNU MP is released under the GNU Lesser General Public License (GNU LGPL).
+GNU MP is dual licensed under under the conditions of the GNU Lesser
+General Public License (LGPL), version 3, or the GNU General Public
+License (GPL), version 2. This is the recipient’s choice, and the
+recipient also has the additional option of applying later versions of
+these licenses.
 
-MPFR is released under the GNU Lesser General Public License (GNU LGPL).
+MPFR is released under the GNU Lesser General Public License (GNU LGPL),
+either version 3 of the license, or (at your option) any later version.

--- a/math-x86_64-macosx/info.rkt
+++ b/math-x86_64-macosx/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +8,8 @@
 (define pkg-desc "native libraries for \"math\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '((Apache-2.0 OR MIT)
+    AND
+    ((LGPL-3.0-or-later OR GPL-2.0-or-later) AND LGPL-3.0-or-later)))

--- a/math-x86_64-macosx/math/info.rkt
+++ b/math-x86_64-macosx/math/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "x86_64-macosx")
 

--- a/pack-all.rkt
+++ b/pack-all.rkt
@@ -1,4 +1,6 @@
 #lang racket/base
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 (require racket/cmdline
          racket/file
          racket/port

--- a/pack-and-upload.rkt
+++ b/pack-and-upload.rkt
@@ -1,4 +1,6 @@
 #lang racket/base
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 (require aws/keys
          aws/s3
          racket/file

--- a/racket-aarch64-macosx-3/LICENSE.txt
+++ b/racket-aarch64-macosx-3/LICENSE.txt
@@ -1,13 +1,13 @@
 racket-aarch64-macosx-3
 
-This package is distributed under the Apache 2.0 and MIT licenses. The
-user can choose the license under which they will be using the
-software. There may be other licenses within the distribution with
-which the user must also comply.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 This package includes libedit software developed for NetBSD under the
 NetBSD license.
 
 This product includes software developed by the OpenSSL Project for
-use in the OpenSSL Toolkit (http://www.openssl.org/).
+use in the OpenSSL Toolkit (https://www.openssl.org/).
 

--- a/racket-aarch64-macosx-3/info.rkt
+++ b/racket-aarch64-macosx-3/info.rkt
@@ -1,8 +1,14 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
 
-(define pkg-desc "native libraries for \"racket\" package")
+(define pkg-desc "native libraries for \"base\" package")
 
 (define pkg-authors '(mflatt))
+
+(define version "1.2")
+
+(define license '((Apache-2.0 OR MIT) AND (BSD-3-clause AND OpenSSL)))

--- a/racket-aarch64-macosx-3/racket/info.rkt
+++ b/racket-aarch64-macosx-3/racket/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "aarch64-macosx")
 

--- a/racket-i386-macosx-2/LICENSE.txt
+++ b/racket-i386-macosx-2/LICENSE.txt
@@ -1,10 +1,10 @@
 racket-i386-macosx-2
 Copyright (c) 2010-2017 PLT Design Inc.
 
-This package is distributed under the Apache 2.0 and MIT licenses. The
-user can choose the license under which they will be using the
-software. There may be other licenses within the distribution with
-which the user must also comply.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 This product includes software developed by the OpenSSL Project for
 use in the OpenSSL Toolkit (http://www.openssl.org/).

--- a/racket-i386-macosx-2/info.rkt
+++ b/racket-i386-macosx-2/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +7,5 @@
 (define pkg-desc "native libraries for \"racket\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license '((Apache-2.0 OR MIT) AND OpenSSL))

--- a/racket-i386-macosx-2/racket/info.rkt
+++ b/racket-i386-macosx-2/racket/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 (define install-platform "i386-macosx")
 

--- a/racket-i386-macosx-3/LICENSE.txt
+++ b/racket-i386-macosx-3/LICENSE.txt
@@ -1,13 +1,13 @@
 racket-i386-macosx-3
-Copyright (c) 2010-2018 PLT Design Inc.
 
-This package is distributed under the Apache 2.0 and MIT licenses. The
-user can choose the license under which they will be using the
-software. There may be other licenses within the distribution with
-which the user must also comply.
-
-This product includes software developed by the OpenSSL Project for
-use in the OpenSSL Toolkit (http://www.openssl.org/).
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 This package includes libedit software developed for NetBSD under the
 NetBSD license.
+
+This product includes software developed by the OpenSSL Project for
+use in the OpenSSL Toolkit (https://www.openssl.org/).
+

--- a/racket-i386-macosx-3/info.rkt
+++ b/racket-i386-macosx-3/info.rkt
@@ -1,10 +1,14 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
 
-(define pkg-desc "native libraries for \"racket\" package")
+(define pkg-desc "native libraries for \"base\" package")
 
 (define pkg-authors '(mflatt))
 
-(define version "1.1")
+(define version "1.2")
+
+(define license '((Apache-2.0 OR MIT) AND (BSD-3-clause AND OpenSSL)))

--- a/racket-i386-macosx-3/racket/info.rkt
+++ b/racket-i386-macosx-3/racket/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "i386-macosx")
 

--- a/racket-ppc-macosx-2/LICENSE.txt
+++ b/racket-ppc-macosx-2/LICENSE.txt
@@ -1,10 +1,10 @@
 racket-ppc-macosx-2
 Copyright (c) 2010-2015 PLT Design Inc.
 
-This package is distributed under the Apache 2.0 and MIT licenses. The
-user can choose the license under which they will be using the
-software. There may be other licenses within the distribution with
-which the user must also comply.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 This product includes software developed by the OpenSSL Project for
 use in the OpenSSL Toolkit (http://www.openssl.org/).

--- a/racket-ppc-macosx-2/info.rkt
+++ b/racket-ppc-macosx-2/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +7,5 @@
 (define pkg-desc "native libraries for \"racket\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license '((Apache-2.0 OR MIT) AND OpenSSL))

--- a/racket-ppc-macosx-2/racket/info.rkt
+++ b/racket-ppc-macosx-2/racket/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 (define install-platform "ppc-macosx")
 

--- a/racket-ppc-macosx-3/LICENSE.txt
+++ b/racket-ppc-macosx-3/LICENSE.txt
@@ -1,11 +1,10 @@
 racket-ppc-macosx-3
-Copyright (c) 2010-2018 PLT Design Inc.
 
-This package is distributed under the Apache 2.0 and MIT licenses. The
-user can choose the license under which they will be using the
-software. There may be other licenses within the distribution with
-which the user must also comply.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 This product includes software developed by the OpenSSL Project for
-use in the OpenSSL Toolkit (http://www.openssl.org/).
+use in the OpenSSL Toolkit (https://www.openssl.org/).
 

--- a/racket-ppc-macosx-3/info.rkt
+++ b/racket-ppc-macosx-3/info.rkt
@@ -1,8 +1,14 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
 
-(define pkg-desc "native libraries for \"racket\" package")
+(define pkg-desc "native libraries for \"base\" package")
 
 (define pkg-authors '(mflatt))
+
+(define version "1.2")
+
+(define license '((Apache-2.0 OR MIT) AND OpenSSL))

--- a/racket-ppc-macosx-3/racket/info.rkt
+++ b/racket-ppc-macosx-3/racket/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "ppc-macosx")
 

--- a/racket-win32-arm64-3/LICENSE.txt
+++ b/racket-win32-arm64-3/LICENSE.txt
@@ -1,17 +1,17 @@
 racket-win32-arm64-3
 
-This package is distributed under the Apache 2.0 and MIT licenses. The
-user can choose the license under which they will be using the
-software. There may be other licenses within the distribution with
-which the user must also comply.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 libiconv is released under the GNU Lesser General Public License (GNU LGPL).
 
 This product includes software developed by the OpenSSL Project for
-use in the OpenSSL Toolkit (http://www.openssl.org/).
+use in the OpenSSL Toolkit (https://www.openssl.org/).
 
 Eric Young is the author of libeay and ssleay.
 
 The source to longdouble is included with the Racket source code,
 which is available from
-  http://www.racket-lang.org/
+  https://www.racket-lang.org/

--- a/racket-win32-arm64-3/info.rkt
+++ b/racket-win32-arm64-3/info.rkt
@@ -1,8 +1,14 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
 
-(define pkg-desc "native libraries for \"racket\" package")
+(define pkg-desc "native libraries for \"base\" package")
 
 (define pkg-authors '(mflatt))
+
+(define version "1.2")
+
+(define license '((Apache-2.0 OR MIT) AND (LGPL-3.0-or-later AND OpenSSL)))

--- a/racket-win32-arm64-3/racket/info.rkt
+++ b/racket-win32-arm64-3/racket/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "win32\\arm64")
 

--- a/racket-win32-i386-2/LICENSE.txt
+++ b/racket-win32-i386-2/LICENSE.txt
@@ -1,21 +1,18 @@
 racket-win32-i386-2
 Copyright (c) 2010-2017 PLT Design Inc.
 
-
-Individual components of this package are distributed under a multiple
-licenses. Specifically, libiconv is distributed under the GNU Lesser
-General Public License. The reminder of this package is distributed
-under the Apache 2.0 and MIT licenses. The user can choose the license
-under which they will be using the software. There may be other
-licenses within the distribution with which the user must also comply.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 libiconv is released under the GNU Lesser General Public License (GNU LGPL).
 
 This product includes software developed by the OpenSSL Project for
-use in the OpenSSL Toolkit (http://www.openssl.org/).
+use in the OpenSSL Toolkit (https://www.openssl.org/).
 
 Eric Young is the author of libeay and ssleay.
 
 The source to longdouble is included with the Racket source code,
 which is available from
-  http://www.racket-lang.org/
+  https://www.racket-lang.org/

--- a/racket-win32-i386-2/info.rkt
+++ b/racket-win32-i386-2/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +7,5 @@
 (define pkg-desc "native libraries for \"racket\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license '((Apache-2.0 OR MIT) AND (LGPL-3.0-or-later AND OpenSSL)))

--- a/racket-win32-i386-2/racket/info.rkt
+++ b/racket-win32-i386-2/racket/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 (define install-platform "win32\\i386")
 

--- a/racket-win32-i386-3/LICENSE.txt
+++ b/racket-win32-i386-3/LICENSE.txt
@@ -1,21 +1,17 @@
 racket-win32-i386-3
-Copyright (c) 2010-2018 PLT Design Inc.
 
-
-Individual components of this package are distributed under a multiple
-licenses. Specifically, libiconv is distributed under the GNU Lesser
-General Public License. The reminder of this package is distributed
-under the Apache 2.0 and MIT licenses. The user can choose the license
-under which they will be using the software. There may be other
-licenses within the distribution with which the user must also comply.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 libiconv is released under the GNU Lesser General Public License (GNU LGPL).
 
 This product includes software developed by the OpenSSL Project for
-use in the OpenSSL Toolkit (http://www.openssl.org/).
+use in the OpenSSL Toolkit (https://www.openssl.org/).
 
 Eric Young is the author of libeay and ssleay.
 
 The source to longdouble is included with the Racket source code,
 which is available from
-  http://www.racket-lang.org/
+  https://www.racket-lang.org/

--- a/racket-win32-i386-3/info.rkt
+++ b/racket-win32-i386-3/info.rkt
@@ -1,8 +1,14 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
 
-(define pkg-desc "native libraries for \"racket\" package")
+(define pkg-desc "native libraries for \"base\" package")
 
 (define pkg-authors '(mflatt))
+
+(define version "1.2")
+
+(define license '((Apache-2.0 OR MIT) AND (LGPL-3.0-or-later AND OpenSSL)))

--- a/racket-win32-i386-3/racket/info.rkt
+++ b/racket-win32-i386-3/racket/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "win32\\i386")
 

--- a/racket-win32-i386/LICENSE.txt
+++ b/racket-win32-i386/LICENSE.txt
@@ -1,16 +1,18 @@
 racket-win32-i386
 Copyright (c) 2010-2014 PLT Design Inc.
 
-This package is distributed under the Apache 2.0 and MIT licenses. The
-user can choose the license under which they will be using the
-software. There may be other licenses within the distribution with
-which the user must also comply.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
+
+libiconv is released under the GNU Lesser General Public License (GNU LGPL).
 
 This product includes software developed by the OpenSSL Project for
-use in the OpenSSL Toolkit (http://www.openssl.org/).
+use in the OpenSSL Toolkit (https://www.openssl.org/).
 
 Eric Young is the author of libeay and ssleay.
 
 The source to longdouble is included with the Racket source code,
 which is available from
-  http://www.racket-lang.org/
+  https://www.racket-lang.org/

--- a/racket-win32-i386/info.rkt
+++ b/racket-win32-i386/info.rkt
@@ -1,7 +1,11 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 (define collection 'multi)
 (define deps '("base"))
 
 (define pkg-desc "native libraries for \"base\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license '((Apache-2.0 OR MIT) AND (LGPL-3.0-or-later AND OpenSSL)))

--- a/racket-win32-i386/racket/info.rkt
+++ b/racket-win32-i386/racket/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 (define copy-foreign-libs (quote ("iconv.dll" "libeay32.dll" "ssleay32.dll" "longdouble.dll")))
-(define collection 'multi)
 (define install-platform "win32\\i386")

--- a/racket-win32-x86_64-2/LICENSE.txt
+++ b/racket-win32-x86_64-2/LICENSE.txt
@@ -1,20 +1,18 @@
 racket-win32-x86_64-2
 Copyright (c) 2010-2017 PLT Design Inc.
 
-Individual components of this package are distributed under a multiple
-licenses. Specifically, libiconv is distributed under the GNU Lesser
-General Public License. The reminder of this package is distributed
-under the Apache 2.0 and MIT licenses. The user can choose the license
-under which they will be using the software. There may be other
-licenses within the distribution with which the user must also comply.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 libiconv is released under the GNU Lesser General Public License (GNU LGPL).
 
 This product includes software developed by the OpenSSL Project for
-use in the OpenSSL Toolkit (http://www.openssl.org/).
+use in the OpenSSL Toolkit (https://www.openssl.org/).
 
 Eric Young is the author of libeay and ssleay.
 
 The source to longdouble is included with the Racket source code,
 which is available from
-  http://www.racket-lang.org/
+  https://www.racket-lang.org/

--- a/racket-win32-x86_64-2/info.rkt
+++ b/racket-win32-x86_64-2/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +7,5 @@
 (define pkg-desc "native libraries for \"racket\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license '((Apache-2.0 OR MIT) AND (LGPL-3.0-or-later AND OpenSSL)))

--- a/racket-win32-x86_64-2/racket/info.rkt
+++ b/racket-win32-x86_64-2/racket/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 (define install-platform "win32\\x86_64")
 

--- a/racket-win32-x86_64-3/LICENSE.txt
+++ b/racket-win32-x86_64-3/LICENSE.txt
@@ -1,20 +1,17 @@
 racket-win32-x86_64-3
-Copyright (c) 2010-2018 PLT Design Inc.
 
-Individual components of this package are distributed under a multiple
-licenses. Specifically, libiconv is distributed under the GNU Lesser
-General Public License. The reminder of this package is distributed
-under the Apache 2.0 and MIT licenses. The user can choose the license
-under which they will be using the software. There may be other
-licenses within the distribution with which the user must also comply.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 libiconv is released under the GNU Lesser General Public License (GNU LGPL).
 
 This product includes software developed by the OpenSSL Project for
-use in the OpenSSL Toolkit (http://www.openssl.org/).
+use in the OpenSSL Toolkit (https://www.openssl.org/).
 
 Eric Young is the author of libeay and ssleay.
 
 The source to longdouble is included with the Racket source code,
 which is available from
-  http://www.racket-lang.org/
+  https://www.racket-lang.org/

--- a/racket-win32-x86_64-3/info.rkt
+++ b/racket-win32-x86_64-3/info.rkt
@@ -1,8 +1,14 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
 
-(define pkg-desc "native libraries for \"racket\" package")
+(define pkg-desc "native libraries for \"base\" package")
 
 (define pkg-authors '(mflatt))
+
+(define version "1.2")
+
+(define license '((Apache-2.0 OR MIT) AND (LGPL-3.0-or-later AND OpenSSL)))

--- a/racket-win32-x86_64-3/racket/info.rkt
+++ b/racket-win32-x86_64-3/racket/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "win32\\x86_64")
 

--- a/racket-win32-x86_64/LICENSE.txt
+++ b/racket-win32-x86_64/LICENSE.txt
@@ -1,16 +1,18 @@
 racket-win32-x86_64
 Copyright (c) 2010-2014 PLT Design Inc.
 
-This package is distributed under the Apache 2.0 and MIT licenses. The
-user can choose the license under which they will be using the
-software. There may be other licenses within the distribution with
-which the user must also comply.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
+
+libiconv is released under the GNU Lesser General Public License (GNU LGPL).
 
 This product includes software developed by the OpenSSL Project for
-use in the OpenSSL Toolkit (http://www.openssl.org/).
+use in the OpenSSL Toolkit (https://www.openssl.org/).
 
 Eric Young is the author of libeay and ssleay.
 
 The source to longdouble is included with the Racket source code,
 which is available from
-  http://www.racket-lang.org/
+  https://www.racket-lang.org/

--- a/racket-win32-x86_64/info.rkt
+++ b/racket-win32-x86_64/info.rkt
@@ -1,7 +1,11 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 (define collection 'multi)
 (define deps '("base"))
 
 (define pkg-desc "native libraries for \"base\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license '((Apache-2.0 OR MIT) AND (LGPL-3.0-or-later AND OpenSSL)))

--- a/racket-win32-x86_64/racket/info.rkt
+++ b/racket-win32-x86_64/racket/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
 (define copy-foreign-libs (quote ("libiconv-2.dll" "libeay32.dll" "ssleay32.dll" "longdouble.dll")))
-(define collection 'multi)
 (define install-platform "win32\\x86_64")

--- a/racket-x86_64-linux-natipkg-2/LICENSE.txt
+++ b/racket-x86_64-linux-natipkg-2/LICENSE.txt
@@ -1,10 +1,10 @@
 racket-x86_64-linux-natipkg-2
 Copyright (c) 2010-2014 PLT Design Inc.
 
-This package is distributed under the Apache 2.0 and MIT licenses. The
-user can choose the license under which they will be using the
-software. There may be other licenses within the distribution with
-which the user must also comply.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 This product includes software developed by the OpenSSL Project for
 use in the OpenSSL Toolkit (http://www.openssl.org/).

--- a/racket-x86_64-linux-natipkg-2/info.rkt
+++ b/racket-x86_64-linux-natipkg-2/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +7,5 @@
 (define pkg-desc "native libraries for \"racket\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license '((Apache-2.0 OR MIT) AND OpenSSL))

--- a/racket-x86_64-linux-natipkg-2/racket/info.rkt
+++ b/racket-x86_64-linux-natipkg-2/racket/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 (define install-platform "x86_64-linux-natipkg")
 

--- a/racket-x86_64-linux-natipkg-3/LICENSE.txt
+++ b/racket-x86_64-linux-natipkg-3/LICENSE.txt
@@ -1,11 +1,10 @@
 racket-x86_64-linux-natipkg-3
-Copyright (c) 2010-2018 PLT Design Inc.
 
-This package is distributed under the Apache 2.0 and MIT licenses. The
-user can choose the license under which they will be using the
-software. There may be other licenses within the distribution with
-which the user must also comply.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 This product includes software developed by the OpenSSL Project for
-use in the OpenSSL Toolkit (http://www.openssl.org/).
+use in the OpenSSL Toolkit (https://www.openssl.org/).
 

--- a/racket-x86_64-linux-natipkg-3/info.rkt
+++ b/racket-x86_64-linux-natipkg-3/info.rkt
@@ -1,8 +1,14 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
 
-(define pkg-desc "native libraries for \"racket\" package")
+(define pkg-desc "native libraries for \"base\" package")
 
 (define pkg-authors '(mflatt))
+
+(define version "1.2")
+
+(define license '((Apache-2.0 OR MIT) AND OpenSSL))

--- a/racket-x86_64-linux-natipkg-3/racket/info.rkt
+++ b/racket-x86_64-linux-natipkg-3/racket/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "x86_64-linux-natipkg")
 

--- a/racket-x86_64-macosx-2/LICENSE.txt
+++ b/racket-x86_64-macosx-2/LICENSE.txt
@@ -1,10 +1,10 @@
 racket-x86_64-macosx-2
 Copyright (c) 2010-2017 PLT Design Inc.
 
-This package is distributed under the Apache 2.0 and MIT licenses. The
-user can choose the license under which they will be using the
-software. There may be other licenses within the distribution with
-which the user must also comply.
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 This product includes software developed by the OpenSSL Project for
 use in the OpenSSL Toolkit (http://www.openssl.org/).

--- a/racket-x86_64-macosx-2/info.rkt
+++ b/racket-x86_64-macosx-2/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 (define collection 'multi)
 (define deps '("base"))
@@ -6,3 +7,5 @@
 (define pkg-desc "native libraries for \"racket\" package")
 
 (define pkg-authors '(mflatt))
+
+(define license '((Apache-2.0 OR MIT) AND OpenSSL))

--- a/racket-x86_64-macosx-2/racket/info.rkt
+++ b/racket-x86_64-macosx-2/racket/info.rkt
@@ -1,4 +1,5 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 (define install-platform "x86_64-macosx")
 

--- a/racket-x86_64-macosx-3/LICENSE.txt
+++ b/racket-x86_64-macosx-3/LICENSE.txt
@@ -1,12 +1,13 @@
 racket-x86_64-macosx-3
 
-This package is distributed under the Apache 2.0 and MIT licenses. The
-user can choose the license under which they will be using the
-software. There may be other licenses within the distribution with
-which the user must also comply.
-
-This product includes software developed by the OpenSSL Project for
-use in the OpenSSL Toolkit (http://www.openssl.org/).
+The Racket code in this package is distributed under the Apache 2.0
+and MIT licenses. The user can choose the license under which they
+will be using the software. There may be other licenses within the
+distribution with which the user must also comply.
 
 This package includes libedit software developed for NetBSD under the
 NetBSD license.
+
+This product includes software developed by the OpenSSL Project for
+use in the OpenSSL Toolkit (https://www.openssl.org/).
+

--- a/racket-x86_64-macosx-3/info.rkt
+++ b/racket-x86_64-macosx-3/info.rkt
@@ -1,10 +1,14 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define collection 'multi)
 (define deps '("base"))
 
-(define pkg-desc "native libraries for \"racket\" package")
+(define pkg-desc "native libraries for \"base\" package")
 
 (define pkg-authors '(mflatt))
 
-(define version "1.1")
+(define version "1.2")
+
+(define license '((Apache-2.0 OR MIT) AND (BSD-3-clause AND OpenSSL)))

--- a/racket-x86_64-macosx-3/racket/info.rkt
+++ b/racket-x86_64-macosx-3/racket/info.rkt
@@ -1,4 +1,6 @@
 #lang setup/infotab
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
+;; THIS FILE IS AUTO-GENERATED FROM racket/src/native-libs/install.rkt
 
 (define install-platform "x86_64-macosx")
 


### PR DESCRIPTION
This should cover the equivalent of <https://github.com/racket/libs/pull/3>—thanks to @spdegabrielle and @Aeva for nudging this along!

I still have to do the `racket-*` and `gui-*` packages, but I'm opening this now as a draft because some questions came up with the `draw-*` packages.

I noticed that:

  - The `draw-*-macosx` (no suffix) packages don't have libexpat or fontconfig.

  - The `draw-win32-{x86_64,i386}` (no suffix) packages don't have pixman or libffi.

  - The `draw-win32-i386` (no suffix) package also lacks libintl.

Are these real differences, or are the contents just in different object files?

In `draw-ttf-x86_64-linux-natipkg`, the copyright statement in LICENSE.txt seemed to have come from FontConfig, but the actual fonts seem to be GNU FreeFont. Does that seem right?

<hr/>

Some other thoughts that are probably out of scope for this PR:

 1. I found https://github.com/racket/racket/issues/4286 and https://github.com/racket/racket/issues/4287 while working on this, but I haven't checked the other libraries.
 2. I think it would be good to record what versions of the libraries are packaged.
 3. I think we may need to do more for the LGPL libraries about providing the *corresponding* source and perhaps copies of licenses, and I don't know in general if we have all the acknowledgements we need.

I'm confident these changes will be an improvement over the status quo, but I'm not a lawyer, and I don't often distribute binaries. It seems like this repository would be an especially valuable place to ask the Conservancy to check that all of the details are right, both for Racket's sake and to avoid creating problems for users or redistributors.